### PR TITLE
Wrap Integration Partners component in a div for consistent background in light mode

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,7 +13,9 @@ export default function Home() {
       <AboutSection />
       <PlatformFeatures />
       <DeveloperAndSupport />
-      <IntegrationPartners />
+      <div className="w-full bg-white dark:bg-[#0A0F23]">
+        <IntegrationPartners />
+      </div>
       <FAQSection />
       <GetInTouch />
     </main>

--- a/src/components/common/IntegrationPartners.tsx
+++ b/src/components/common/IntegrationPartners.tsx
@@ -21,14 +21,14 @@ const IntegrationPartners = () => {
   ];
 
   return (
-    <section className="py-16 container mx-auto px-4">
+    <section className="py-16 container mx-auto px-4 bg-white dark:bg-[#0A0F23]">
       <div className="text-center mb-12">
         <h2 className="text-4xl md:text-5xl font-bold mb-4">
           <span className="bg-gradient-to-r from-blue-400 via-purple-400 to-cyan-400 bg-clip-text text-transparent">
             Integration Partners
           </span>
         </h2>
-        <p className="text-white">Connect with your favorite platforms</p>
+        <p className="text-gray-700 dark:text-white">Connect with your favorite platforms</p>
       </div>
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-2 gap-8 max-w-4xl mx-auto">
         {partners.map((partner) => (
@@ -50,11 +50,11 @@ const IntegrationPartners = () => {
                 {partner.name}
               </span>
             </h3>
-            <p className="text-white mb-4">{partner.description}</p>
+            <p className="text-gray-700 dark:text-white mb-4">{partner.description}</p>
             {partner.features && (
               <ul className="list-disc text-left space-y-2 mt-2">
                 {partner.features.map((feature, index) => (
-                  <li key={index} className="text-white ml-4">{feature}</li>
+                  <li key={index} className="text-gray-700 dark:text-white ml-4">{feature}</li>
                 ))}
               </ul>
             )}


### PR DESCRIPTION
Description:
Ensure the Integration Partners section has a solid white background in light mode and a dark background in dark mode by wrapping it in a full-width container.
Prevents the underlying page gradient from showing at the bottom of the section.
Also updates text colors for better visibility in both light and dark themes.