### PR TITLE
Fix : invalid HTML nesting in FAQSection

### DIFF
--- a/src/components/common/FAQSection.tsx
+++ b/src/components/common/FAQSection.tsx
@@ -104,9 +104,9 @@ export default function FAQSection() {
               </button>
               {openIndex === index && (
                 <div className="px-6 pb-4">
-                  <p className="text-slate-600 dark:text-slate-300">
+                  <div className="text-slate-600 dark:text-slate-300">
                     {faq.answer}
-                  </p>
+                  </div>
                 </div>
               )}
             </div>


### PR DESCRIPTION
This PR resolves a hydration error caused by rendering a `<ul>` inside a `<p>` tag in the FAQSection component. The answer container is now a `<div>`, ensuring valid HTML structure and preventing hydration issues in React/Next.js. No visual or functional changes to the FAQ display.